### PR TITLE
chore: Adds formatting configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,19 @@
+---
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLoopsOnASingleLine: 'false'
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Allman
+ColumnLimit: '100'
+ExperimentalAutoDetectBinPacking: false
+IncludeBlocks: Regroup
+IndentWidth: '4'
+Language: Cpp
+NamespaceIndentation: All
+SortIncludes: 'true'
+TabWidth: '4'
+UseTab: Never
+...

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,7 +62,6 @@
     "particle.targetPlatform": "tracker",
     "particle.targetDevice": "",
     "cmake.configureOnOpen": false,
-    "C_Cpp.codeAnalysis.clangTidy.enabled": false,
     "C_Cpp.default.cppStandard": "c++11",
     "C_Cpp.default.cStandard": "c11",
     "C_Cpp.doxygen.generatedStyle": "/**",
@@ -71,14 +70,11 @@
         80
     ],
     "particle.enableVerboseLocalCompilerLogging": true,
-    "C_Cpp.vcFormat.space.pointerReferenceAlignment": "left",
-    "C_Cpp.formatting": "vcFormat",
-    "C_Cpp.vcFormat.newLine.scopeBracesOnSeparateLines": true,
-    "C_Cpp.vcFormat.newLine.beforeOpenBrace.type": "newLine",
-    "C_Cpp.vcFormat.newLine.beforeOpenBrace.block": "newLine",
-    "C_Cpp.vcFormat.indent.preserveWithinParentheses": true,
-    "C_Cpp.vcFormat.indent.preprocessor": "oneLeft",
     "plantuml.render": "PlantUMLServer",
     "plantuml.server": "https://www.plantuml.com/plantuml",
-
+    "C_Cpp.formatting": "clangFormat",
+    "editor.formatOnPaste": true,
+    "editor.formatOnSave": true,
+    "editor.formatOnSaveMode": "modifications",
+    "editor.formatOnType": true,
 }


### PR DESCRIPTION
Using LLVM .clang-format and custom configuration, enables format on past, save, and type.