### PR TITLE
Re-enabled doxygen fail of warning

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -901,7 +901,7 @@ WARN_IF_UNDOC_ENUM_VAL = YES
 # Possible values are: NO, YES, FAIL_ON_WARNINGS and FAIL_ON_WARNINGS_PRINT.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = FAIL_ON_WARNINGS_PRINT
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which


### PR DESCRIPTION
Changed WARN_AS_ERROR from NO to FAIL_ON_WARNINGS_PRINT