### PR TITLE
doc: Added doc for CLI_debugMenu[]

### DIFF
--- a/src/cli/cliDebug.cpp
+++ b/src/cli/cliDebug.cpp
@@ -32,7 +32,9 @@
 
 #include "Particle.h"
 
-
+/**
+ * @brief Command line debugging menu
+ */
 const Menu_t CLI_debugMenu[] = 
 {
     {1, "Display Fault Log", &CLI_displayFLOG, MENU_CMD},


### PR DESCRIPTION
Not sure if this is enough documentation, so please let me know if I should add more. Also, cli in this context stands for command line, right? (Issue #82)