### PR TITLE
docs: fixed CLI_monitorTempSensor(void) doc

### DIFF
--- a/src/cli/menuItems/debugCommands.hpp
+++ b/src/cli/menuItems/debugCommands.hpp
@@ -36,9 +36,8 @@ void CLI_testHasData(void);
  * @brief Delete all files
 */
 void CLI_wipeFileSystem(void);
-/*
- * @brief Monitors temperature sensor
- * 
+/**
+ * @brief Monitor temperature sensor
  */
 void CLI_monitorTempSensor(void);
 /**


### PR DESCRIPTION
I think I fixed the doc for CLI_monitorTempSensor(void) by editing src/cli/menuItems/debugCommands.hpp. 

However, there are some small inconsistencies in documentation in that file such as extra blank * comment lines in some comments and differences in saying things like "Displays" versus "Display" or "Gets" versus "Get". Should I fix those small inconsistencies or leave as is for now?