### PR TITLE
docs: Fixed formatting of tables in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,28 +26,29 @@ base85          | 9c52d27 | MIT     | https://github.com/rafagafe/base85 | src/c
 # LED Behavior
 
 ## Status LED
-State              | Color    | Pattern
----------------------------------------
-Charge             | Yellow   | Solid
-Sleep              | Black    | Solid
-CLI                | Red      | Solid
-Network Off        | Black    | Solid
-Network On         | Blue     | Solid
-Network Connecting | Blue     | Solid
-Network DHCP       | Blue     | Solid
-Cloud Connecting   | Blue     | Solid
-Cloud Connected    | Blue     | Blink
-Cloud Handshake    | Blue     | Blink
+| State              | Color  | Pattern  |
+|--------------------|--------|----------|
+| Charge             | Yellow | Solid    |
+| Sleep              | Black  | Solid    |
+| CLI                | Red    | Solid    |
+| Network Off        | Black  | Solid    |
+| Network On         | Blue   | Solid    |
+| Network Connecting | Blue   | Solid    |
+| Network DHCP       | Blue   | Solid    |
+| Cloud Connecting   | Blue   | Solid    |
+| Cloud Connected    | Blue   | Blink    |
+| Cloud Handshake    | Blue   | Blink    |
 
 
 ## Battery LED
-Condition                                    | Battery LED State   |
---------------------------------------------------------------------|
-No charger                                    | LED OFF             |
-Is charging and less than 60 ms have passed   | No Change           |
-Is charging and at least 60 ms have passed    | LED Blinking        |
-Not charging and less than 10 ms have passed  | No Change           |
-Not charging and at least 10 ms have passed   | LED ON              |
+| Condition                                    | Battery LED State |
+|----------------------------------------------|-------------------|
+| No charger                                   | LED OFF           |
+| Is charging and less than 60 ms have passed  | No Change         |
+| Is charging and at least 60 ms have passed   | LED Blinking      |
+| Not charging and less than 10 ms have passed | No Change         |
+| Not charging and at least 10 ms have passed  | LED ON            |
+
 
 ## Wet Dry LED
 TODO


### PR DESCRIPTION
Fixed issue #42, the tables should now show in the README.