### PR TITLE
Include DEL (127 in ASCII) input to be recognized as backspace

### DIFF
--- a/src/cli/conio.cpp
+++ b/src/cli/conio.cpp
@@ -127,6 +127,7 @@ extern "C"
                 userInput = SF_OSAL_getch();
                 switch (userInput)
                 {
+                case 127:
                 case '\b':
                     i--;
                     SF_OSAL_putch('\b');


### PR DESCRIPTION
Fixes #173 by recognizing DEL input as backspace.