### PR TITLE
Output doxygen to /doxygen

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -68,7 +68,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docs
+OUTPUT_DIRECTORY       = doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create up to 4096
 # sub-directories (in 2 levels) under the output directory of each output format


### PR DESCRIPTION
Doxygen output clashed with existing /docs, so now it will output into its own directory /doxygen.