### PR TITLE
29 doxygen output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,12 +46,12 @@ jobs:
             particle-platform-name: 'tracker'
             device-os-version: '5.3.0'
       - name: Compile Documentation
-        id: docs
+        id: doxygen
         uses: mattnotmitt/doxygen-action@1.9.8
 
       - name: Check outputs
         run: |
-          ls -alh docs/html
+          ls -alh doxygen/html
           
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -60,7 +60,7 @@ jobs:
             path: |
                 ${{ steps.compile.outputs.firmware-path }}
                 ${{ steps.compile.outputs.target-path }}
-                docs/html
+                doxygen/html
                 doxygen.log
 
   release:

--- a/Doxyfile
+++ b/Doxyfile
@@ -68,7 +68,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docs
+OUTPUT_DIRECTORY       = doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create up to 4096
 # sub-directories (in 2 levels) under the output directory of each output format


### PR DESCRIPTION
Doxygen output clashed with existing /docs, so now it will output into its own directory /doxygen. Github workflow edited accordingly.