### PR TITLE
Replace cellular-upload direction with BLE-first streaming foundation

### DIFF
--- a/src/ble/sf_ble.cpp
+++ b/src/ble/sf_ble.cpp
@@ -1,0 +1,348 @@
+/**
+ * @file sf_ble.cpp
+ * @brief Particle-backed implementation of the platform-adaptable BLE wrapper.
+ * @author Charlie Kushelevsky (ckushelevsky@ucsd.edu)
+ * @date 3-9-2026
+ */
+
+#include "sf_ble_defs.hpp"
+#include "sf_ble.hpp"
+
+#include "cli/conio.hpp"
+#include "product.hpp"
+
+#if SF_PLATFORM == SF_PLATFORM_PARTICLE
+#include "Particle.h"
+#endif
+
+
+#if SF_PLATFORM == SF_PLATFORM_PARTICLE
+
+namespace
+{
+    /**
+     * @brief Particle-specific implementation 
+     */
+
+    
+    BleUuid g_serviceUuid(sf::bledefs::SERVICE_UUID);
+    BleUuid g_telemetryUuid(sf::bledefs::TELEMETRY_CHAR_UUID);
+    BleUuid g_controlUuid(sf::bledefs::CONTROL_CHAR_UUID);
+
+    /**
+     * @brief Particle BLE backend that wires characteristics and event hooks.
+     */
+    class ParticleBleBackend
+    {
+    public:
+        /**
+         * @brief Construct BLE characteristics and hook control handler.
+         */
+        ParticleBleBackend() :
+            telemetryCharacteristic(
+                "tele",
+                BleCharacteristicProperty::NOTIFY,
+                g_telemetryUuid,
+                g_serviceUuid
+            ),
+            controlCharacteristic(
+                "ctrl",
+                BleCharacteristicProperty::WRITE_WO_RSP,
+                g_controlUuid,
+                g_serviceUuid,
+                ParticleBleBackend::onControlReceivedStatic,
+                this
+            )
+        {
+        }
+
+        BleCharacteristic telemetryCharacteristic;
+        BleCharacteristic controlCharacteristic;
+
+        /** @brief Access singleton backend instance. */
+        static ParticleBleBackend& getInstance()
+        {
+            static ParticleBleBackend instance;
+            return instance;
+        }
+
+        /**
+         * @brief Particle connect callback shim.
+         * @param peer Connected peer (unused).
+         * @param context Pointer to backend instance.
+         */
+        static void onConnectedStatic(const BlePeerDevice& peer, void* context)
+        {
+            (void)peer;
+            ParticleBleBackend* self = static_cast<ParticleBleBackend*>(context);
+            if (self)
+            {
+                self->onConnected();
+            }
+        }
+
+        /**
+         * @brief Particle disconnect callback shim.
+         * @param peer Disconnected peer (unused).
+         * @param context Pointer to backend instance.
+         */
+        static void onDisconnectedStatic(const BlePeerDevice& peer, void* context)
+        {
+            (void)peer;
+            ParticleBleBackend* self = static_cast<ParticleBleBackend*>(context);
+            if (self)
+            {
+                self->onDisconnected();
+            }
+        }
+
+        /**
+         * @brief Particle write-without-response callback shim.
+         * @param data Received payload.
+         * @param len Number of bytes in payload.
+         * @param peer Peer device (unused).
+         * @param context Pointer to backend instance.
+         */
+        static void onControlReceivedStatic(const uint8_t* data,
+                                            size_t len,
+                                            const BlePeerDevice& peer,
+                                            void* context)
+        {
+            (void)peer;
+            ParticleBleBackend* self = static_cast<ParticleBleBackend*>(context);
+            if (self)
+            {
+                self->onControlReceived(data, len);
+            }
+        }
+
+        /**
+         * @brief Invoke connection callback chain on connect.
+         */
+        void onConnected()
+        {
+            SFBLE& ble = SFBLE::getInstance();
+            ble.setConnectionCallback(bleConnectionThunk, &ble);
+            bleConnectionThunk(true, &ble);
+        }
+
+        /**
+         * @brief Invoke connection callback chain on disconnect.
+         */
+        void onDisconnected()
+        {
+            SFBLE& ble = SFBLE::getInstance();
+            ble.setConnectionCallback(bleConnectionThunk, &ble);
+            bleConnectionThunk(false, &ble);
+        }
+
+        /**
+         * @brief Forward control writes to registered handler.
+         * @param data Control payload bytes.
+         * @param len Payload length.
+         */
+        void onControlReceived(const uint8_t* data, size_t len)
+        {
+            SFBLE& ble = SFBLE::getInstance();
+            bleControlThunk(data, len, &ble);
+        }
+
+        /**
+         * @brief Bridge connection events to SFBLE instance.
+         * @param isConnected True if connected, false otherwise.
+         * @param context Pointer to SFBLE instance.
+         */
+        static void bleConnectionThunk(bool isConnected, void* context);
+        /**
+         * @brief Bridge control writes to SFBLE instance.
+         * @param data Control payload.
+         * @param len Payload length.
+         * @param context Pointer to SFBLE instance.
+         */
+        static void bleControlThunk(const uint8_t* data, size_t len, 
+                                                        void* context);
+    };
+
+    void ParticleBleBackend::bleConnectionThunk(bool isConnected, void* context)
+    {
+        SFBLE* ble = static_cast<SFBLE*>(context);
+        if (!ble)
+        {
+            return;
+        }
+
+        ble->connected = isConnected;
+
+        if (ble->connectionCallback)
+        {
+            ble->connectionCallback(isConnected, ble->connectionContext);
+        }
+    }
+
+    void ParticleBleBackend::bleControlThunk(const uint8_t* data, size_t len, 
+                                                                void* context)
+    {
+        SFBLE* ble = static_cast<SFBLE*>(context);
+        if (!ble)
+        {
+            return;
+        }
+
+        if (ble->controlCallback)
+        {
+            ble->controlCallback(data, len, ble->controlContext);
+        }
+    }
+}
+
+/**
+ * @brief Get singleton SFBLE instance.
+ * @return Reference to SFBLE.
+ */
+SFBLE& SFBLE::getInstance(void)
+{
+    static SFBLE instance;
+    return instance;
+}
+
+SFBLE::SFBLE() :
+    initialized(false),
+    connected(false),
+    controlCallback(nullptr),
+    controlContext(nullptr),
+    connectionCallback(nullptr),
+    connectionContext(nullptr)
+{
+}
+
+/**
+ * @brief Initialize BLE stack and register characteristics.
+ * @return true on success, false otherwise.
+ */
+bool SFBLE::init(void)
+{
+    if (this->initialized)
+    {
+        return true;
+    }
+
+#if SF_PLATFORM == SF_PLATFORM_PARTICLE
+    ParticleBleBackend& backend = ParticleBleBackend::getInstance();
+
+    BLE.on();
+    BLE.setDeviceName(sf::bledefs::DEVICE_NAME);
+    BLE.onConnected(ParticleBleBackend::onConnectedStatic, &backend);
+    BLE.onDisconnected(ParticleBleBackend::onDisconnectedStatic, &backend);
+
+    // Register characteristics by referencing them before advertising.
+    // Particle associates the characteristic with the given service UUID in the
+    // BleCharacteristic constructor.
+    (void)backend.telemetryCharacteristic;
+    (void)backend.controlCharacteristic;
+
+    this->initialized = true;
+    return true;
+#else
+    return false;
+#endif
+}
+
+/**
+ * @brief Begin advertising the Smartfin BLE service.
+ * @return true on success, false otherwise.
+ */
+bool SFBLE::startAdvertising(void)
+{
+    if (!this->initialized)
+    {
+        return false;
+    }
+
+#if SF_PLATFORM == SF_PLATFORM_PARTICLE
+    BleAdvertisingData advData;
+    advData.appendServiceUUID(BleUuid(sf::bledefs::SERVICE_UUID));
+    BLE.advertise(&advData);
+    return true;
+#else
+    return false;
+#endif
+}
+
+/**
+ * @brief Stop BLE advertising.
+ * @return true on success, false otherwise.
+ */
+bool SFBLE::stopAdvertising(void)
+{
+    if (!this->initialized)
+    {
+        return false;
+    }
+
+#if SF_PLATFORM == SF_PLATFORM_PARTICLE
+    BLE.stopAdvertising();
+    return true;
+#else
+    return false;
+#endif
+}
+
+/**
+ * @brief Report connection status.
+ * @return true when a central is connected, else false.
+ */
+bool SFBLE::isConnected(void) const
+{
+    return this->connected;
+}
+
+/**
+ * @brief Notify telemetry payload to connected central.
+ * @param pData Pointer to payload.
+ * @param len Payload length in bytes.
+ * @return true on success, false on failure.
+ */
+bool SFBLE::notifyTelemetry(const void* pData, size_t len)
+{
+    if (!this->initialized || !this->connected || !pData)
+    {
+        return false;
+    }
+
+    if (len == 0 || len > sf::bledefs::MAX_NOTIFY_LEN)
+    {
+        return false;
+    }
+
+#if SF_PLATFORM == SF_PLATFORM_PARTICLE
+    ParticleBleBackend& backend = ParticleBleBackend::getInstance();
+    return backend.telemetryCharacteristic.setValue(
+        static_cast<const uint8_t*>(pData),
+        len
+    );
+#else
+    return false;
+#endif
+}
+
+/**
+ * @brief Register callback for incoming control data.
+ * @param cb Callback function pointer.
+ * @param context User context passed to callback.
+ */
+void SFBLE::setControlCallback(control_rx_callback_t cb, void* context)
+{
+    this->controlCallback = cb;
+    this->controlContext = context;
+}
+
+/**
+ * @brief Register callback for connection state changes.
+ * @param cb Callback function pointer.
+ * @param context User context passed to callback.
+ */
+void SFBLE::setConnectionCallback(connection_callback_t cb, void* context)
+{
+    this->connectionCallback = cb;
+    this->connectionContext = context;
+}

--- a/src/ble/sf_ble.cpp
+++ b/src/ble/sf_ble.cpp
@@ -1,366 +1,132 @@
 /**
- * @file sf_ble.cpp
- * @brief Particle backed implementation of the platform adaptable BLE wrapper.
+ * @file sf_ble.hpp
+ * @brief Platform Smartfin BLE wrapper interface.
  * @author Charlie Kushelevsky (ckushelevsky@ucsd.edu)
  * @date 3-9-2026
  */
 
-#include "sf_ble_defs.hpp"
-#include "sf_ble.hpp"
+#ifndef __SF_BLE_HPP__
+#define __SF_BLE_HPP__
 
-#include "cli/conio.hpp"
-#include "product.hpp"
+#include <stddef.h>
+#include <stdint.h>
 
-#if SF_PLATFORM == SF_PLATFORM_PARTICLE
-#include "Particle.h"
-#endif
-
-#if SF_PLATFORM == SF_PLATFORM_PARTICLE
-
-namespace
+/**
+ * @brief Smartfin BLE wrapper.
+ *
+ * Hides Particle BLE types from the rest of the codebase so porting to a
+ * different chip requires changes mostly in the implementation file.
+ *
+ * @note Current intent: peripheral role with one telemetry notify
+ * characteristic and an optional control write characteristic
+ * inside a single custom service.
+ */
+class SFBLE
 {
-    /** @brief Particle specific UUID objects. */
-    BleUuid g_serviceUuid(sf::bledefs::SERVICE_UUID);
-    BleUuid g_telemetryUuid(sf::bledefs::TELEMETRY_CHAR_UUID);
-    BleUuid g_controlUuid(sf::bledefs::CONTROL_CHAR_UUID);
+public:
+    /** @brief Callback invoked on control data received. */
+    typedef void (*control_rx_callback_t)(const uint8_t *data, size_t len, void *context);
+
+    /** @brief Callback invoked on connect/disconnect events. */
+    typedef void (*connection_callback_t)(bool connected, void *context);
+
+    /** @brief Get singleton instance. */
+    static SFBLE &getInstance(void);
 
     /**
-     * @brief Particle BLE backend that wires characteristics and event hooks.
-     *
-     * This class is intentionally confined to this translation unit so the rest
-     * of the codebase does not depend on Particle BLE types.
+     * @brief Initialize BLE stack and register service/characteristics.
+     * @return true on success, false on failure.
      */
-    class ParticleBleBackend
-    {
-    public:
-        /**
-         * @brief Construct BLE characteristics and hook control handler.
-         */
-        ParticleBleBackend() :
-            telemetryCharacteristic(
-                "tele",
-                BleCharacteristicProperty::NOTIFY,
-                g_telemetryUuid,
-                g_serviceUuid
-            ),
-            controlCharacteristic(
-                "ctrl",
-                BleCharacteristicProperty::WRITE_WO_RSP,
-                g_controlUuid,
-                g_serviceUuid,
-                ParticleBleBackend::onControlReceivedStatic,
-                this
-            )
-        {
-        }
+    bool init(void);
 
-        /** @brief Telemetry characteristic for fin -> watch data. */
-        BleCharacteristic telemetryCharacteristic;
+    /**
+     * @brief Start BLE advertising.
+     * @return true on success, false on failure.
+     */
+    bool startAdvertising(void);
 
-        /** @brief Control characteristic for watch -> fin commands. */
-        BleCharacteristic controlCharacteristic;
+    /**
+     * @brief Stop BLE advertising.
+     * @return true on success, false on failure.
+     */
+    bool stopAdvertising(void);
 
-        /** @brief Access singleton backend instance. */
-        static ParticleBleBackend& getInstance()
-        {
-            static ParticleBleBackend instance;
-            return instance;
-        }
+    /**
+     * @brief Returns true if a central is connected.
+     * @return true when a peer is connected, otherwise false.
+     */
+    bool isConnected(void) const;
 
-        /**
-         * @brief Particle connect callback shim.
-         * @param peer Connected peer (unused).
-         * @param context Pointer to backend instance.
-         */
-        static void onConnectedStatic(const BlePeerDevice& peer, void* context)
-        {
-            (void)peer;
-            ParticleBleBackend* self = static_cast<ParticleBleBackend*>(context);
-            if (self)
-            {
-                self->onConnected();
-            }
-        }
+    /**
+     * @brief Send telemetry bytes to connected central using NOTIFY.
+     *
+     * @param pData Pointer to telemetry payload.
+     * @param len Number of bytes to send.
+     * @return true on success, false on failure.
+     */
+    bool notifyTelemetry(const void *pData, size_t len);
 
-        /**
-         * @brief Particle disconnect callback shim.
-         * @param peer Disconnected peer (unused).
-         * @param context Pointer to backend instance.
-         */
-        static void onDisconnectedStatic(const BlePeerDevice& peer, void* context)
-        {
-            (void)peer;
-            ParticleBleBackend* self = static_cast<ParticleBleBackend*>(context);
-            if (self)
-            {
-                self->onDisconnected();
-            }
-        }
+    /**
+     * @brief Register callback for incoming control data.
+     *
+     * @param cb Callback function invoked on received control bytes.
+     * @param context User context pointer passed to the callback.
+     */
+    void setControlCallback(control_rx_callback_t cb, void *context);
 
-        /**
-         * @brief Particle control write callback shim.
-         * @param data Received payload.
-         * @param len Number of bytes in payload.
-         * @param peer Peer device (unused).
-         * @param context Pointer to backend instance.
-         */
-        static void onControlReceivedStatic(const uint8_t* data,
-                                            size_t len,
-                                            const BlePeerDevice& peer,
-                                            void* context)
-        {
-            (void)peer;
-            ParticleBleBackend* self = static_cast<ParticleBleBackend*>(context);
-            if (self)
-            {
-                self->onControlReceived(data, len);
-            }
-        }
+    /**
+     * @brief Register callback for connect/disconnect events.
+     *
+     * @param cb Callback function invoked on connection state changes.
+     * @param context User context pointer passed to the callback.
+     */
+    void setConnectionCallback(connection_callback_t cb, void *context);
+    /**
+     * @brief Internal helper invoked by platform backend on connect/disconnect.
+     *
+     * Updates internal state and forwards to the user callback if registered.
+     *
+     * @param isConnected true if connected, false if disconnected
+     */
+    void handleConnectionEvent(bool isConnected);
 
-        /**
-         * @brief Handle Particle connect event.
-         */
-        void onConnected()
-        {
-            SFBLE &ble = SFBLE::getInstance();
-            bleConnectionThunk(true, &ble);
-        }
+    /**
+     * @brief Internal helper invoked by platform backend on control RX.
+     *
+     * Forwards received control data to the registered callback if present.
+     *
+     * @param data Pointer to received data
+     * @param len Number of bytes received
+     */
+    void handleControlEvent(const uint8_t *data, size_t len);
 
-        /**
-         * @brief Handle Particle disconnect event.
-         */
-        void onDisconnected()
-        {
-            SFBLE &ble = SFBLE::getInstance();
-            bleConnectionThunk(false, &ble);
-        }
+private:
+    /** @brief Private default constructor to enforce singleton. */
+    SFBLE();
 
-        /**
-         * @brief Forward control writes to wrapper.
-         * @param data Control payload bytes.
-         * @param len Payload length.
-         */
-        void onControlReceived(const uint8_t* data, size_t len)
-        {
-            SFBLE& ble = SFBLE::getInstance();
-            bleControlThunk(data, len, &ble);
-        }
+    /** @brief Deleted copy constructor (singleton). */
+    SFBLE(const SFBLE &);
 
-        /**
-         * @brief Bridge connection events to SFBLE instance.
-         * @param isConnected True if connected, false otherwise.
-         * @param context Pointer to SFBLE instance.
-         */
-        static void bleConnectionThunk(bool isConnected, void *context)
-        {
-            SFBLE *ble = static_cast<SFBLE *>(context);
-            if (!ble)
-            {
-                return;
-            }
+    /** @brief Deleted assignment operator (singleton). */
+    SFBLE &operator=(const SFBLE &);
 
-            ble->handleConnectionEvent(isConnected);
-        }
+    /** @brief True after BLE stack/characteristics are initialized. */
+    bool initialized;
 
-        /**
-         * @brief Bridge control writes to SFBLE instance.
-         * @param data Control payload.
-         * @param len Payload length.
-         * @param context Pointer to SFBLE instance.
-         */
-        static void bleControlThunk(const uint8_t *data, size_t len, void *context)
-        {
-            SFBLE *ble = static_cast<SFBLE *>(context);
-            if (!ble)
-            {
-                return;
-            }
+    /** @brief True when a central is currently connected. */
+    bool connected;
 
-            ble->handleControlEvent(data, len);
-        }
-    };
-} // namespace
+    /** @brief Registered control-data callback. */
+    control_rx_callback_t controlCallback;
 
-#endif // SF_PLATFORM == SF_PLATFORM_PARTICLE
+    /** @brief User context for control callback. */
+    void *controlContext;
 
-/**
- * @brief Get singleton SFBLE instance.
- * @return Reference to SFBLE.
- */
-SFBLE& SFBLE::getInstance(void)
-{
-    static SFBLE instance;
-    return instance;
-}
+    /** @brief Registered connection-state callback. */
+    connection_callback_t connectionCallback;
 
-/**
- * @brief Construct default wrapper state.
- */
-SFBLE::SFBLE() :
-    initialized(false),
-    connected(false),
-    controlCallback(nullptr),
-    controlContext(nullptr),
-    connectionCallback(nullptr),
-    connectionContext(nullptr)
-{
-}
+    /** @brief User context for connection callback. */
+    void *connectionContext;
+};
 
-/**
- * @brief Internal connection event handler.
- * @param isConnected true if connected, false otherwise.
- */
-void SFBLE::handleConnectionEvent(bool isConnected)
-{
-    this->connected = isConnected;
-
-    if (this->connectionCallback)
-    {
-        this->connectionCallback(isConnected, this->connectionContext);
-    }
-}
-
-/**
- * @brief Internal control event handler.
- * @param data Pointer to received payload.
- * @param len Payload length.
- */
-void SFBLE::handleControlEvent(const uint8_t *data, size_t len)
-{
-    if (this->controlCallback)
-    {
-        this->controlCallback(data, len, this->controlContext);
-    }
-}
-
-/**
- * @brief Initialize BLE stack and register characteristics.
- * @return true on success, false otherwise.
- */
-bool SFBLE::init(void)
-{
-    if (this->initialized)
-    {
-        return true;
-    }
-
-#if SF_PLATFORM == SF_PLATFORM_PARTICLE
-    ParticleBleBackend& backend = ParticleBleBackend::getInstance();
-
-    BLE.on();
-    BLE.setDeviceName(sf::bledefs::DEVICE_NAME);
-    BLE.onConnected(ParticleBleBackend::onConnectedStatic, &backend);
-    BLE.onDisconnected(ParticleBleBackend::onDisconnectedStatic, &backend);
-
-    // Ensure characteristic objects are instantiated before advertising.
-    (void)backend.telemetryCharacteristic;
-    (void)backend.controlCharacteristic;
-
-    this->initialized = true;
-    return true;
-#else
-    return false;
-#endif
-}
-
-/**
- * @brief Begin advertising the Smartfin BLE service.
- * @return true on success, false otherwise.
- */
-bool SFBLE::startAdvertising(void)
-{
-    if (!this->initialized)
-    {
-        return false;
-    }
-
-#if SF_PLATFORM == SF_PLATFORM_PARTICLE
-    BleAdvertisingData advData;
-    advData.appendServiceUUID(BleUuid(sf::bledefs::SERVICE_UUID));
-    BLE.advertise(&advData);
-    return true;
-#else
-    return false;
-#endif
-}
-
-/**
- * @brief Stop BLE advertising.
- * @return true on success, false otherwise.
- */
-bool SFBLE::stopAdvertising(void)
-{
-    if (!this->initialized)
-    {
-        return false;
-    }
-
-#if SF_PLATFORM == SF_PLATFORM_PARTICLE
-    BLE.stopAdvertising();
-    return true;
-#else
-    return false;
-#endif
-}
-
-/**
- * @brief Report connection status.
- * @return true when a central is connected, else false.
- */
-bool SFBLE::isConnected(void) const
-{
-    return this->connected;
-}
-
-/**
- * @brief Notify telemetry payload to connected central.
- * @param pData Pointer to payload.
- * @param len Payload length in bytes.
- * @return true on success, false on failure.
- */
-bool SFBLE::notifyTelemetry(const void* pData, size_t len)
-{
-    if (!this->initialized || !this->connected || !pData)
-    {
-        return false;
-    }
-
-    if (len == 0 || len > sf::bledefs::MAX_NOTIFY_LEN)
-    {
-        return false;
-    }
-
-#if SF_PLATFORM == SF_PLATFORM_PARTICLE
-    ParticleBleBackend& backend = ParticleBleBackend::getInstance();
-    return backend.telemetryCharacteristic.setValue(
-        static_cast<const uint8_t*>(pData),
-        len
-    );
-#else
-    return false;
-#endif
-}
-
-/**
- * @brief Register callback for incoming control data.
- * @param cb Callback function pointer.
- * @param context User context passed to callback.
- */
-void SFBLE::setControlCallback(control_rx_callback_t cb, void* context)
-{
-    this->controlCallback = cb;
-    this->controlContext = context;
-}
-
-/**
- * @brief Register callback for connection state changes.
- * @param cb Callback function pointer.
- * @param context User context passed to callback.
- */
-void SFBLE::setConnectionCallback(connection_callback_t cb, void* context)
-{
-    this->connectionCallback = cb;
-    this->connectionContext = context;
-}
-
-#endif // SF_PLATFORM == SF_PLATFORM_PARTICLE
+#endif // __SF_BLE_HPP__

--- a/src/ble/sf_ble.cpp
+++ b/src/ble/sf_ble.cpp
@@ -1,6 +1,6 @@
 /**
  * @file sf_ble.cpp
- * @brief Particle-backed implementation of the platform-adaptable BLE wrapper.
+ * @brief Particle backed implementation of the platform adaptable BLE wrapper.
  * @author Charlie Kushelevsky (ckushelevsky@ucsd.edu)
  * @date 3-9-2026
  */
@@ -15,22 +15,20 @@
 #include "Particle.h"
 #endif
 
-
 #if SF_PLATFORM == SF_PLATFORM_PARTICLE
 
 namespace
 {
-    /**
-     * @brief Particle-specific implementation 
-     */
-
-    
+    /** @brief Particle specific UUID objects. */
     BleUuid g_serviceUuid(sf::bledefs::SERVICE_UUID);
     BleUuid g_telemetryUuid(sf::bledefs::TELEMETRY_CHAR_UUID);
     BleUuid g_controlUuid(sf::bledefs::CONTROL_CHAR_UUID);
 
     /**
      * @brief Particle BLE backend that wires characteristics and event hooks.
+     *
+     * This class is intentionally confined to this translation unit so the rest
+     * of the codebase does not depend on Particle BLE types.
      */
     class ParticleBleBackend
     {
@@ -56,7 +54,10 @@ namespace
         {
         }
 
+        /** @brief Telemetry characteristic for fin -> watch data. */
         BleCharacteristic telemetryCharacteristic;
+
+        /** @brief Control characteristic for watch -> fin commands. */
         BleCharacteristic controlCharacteristic;
 
         /** @brief Access singleton backend instance. */
@@ -97,7 +98,7 @@ namespace
         }
 
         /**
-         * @brief Particle write-without-response callback shim.
+         * @brief Particle control write callback shim.
          * @param data Received payload.
          * @param len Number of bytes in payload.
          * @param peer Peer device (unused).
@@ -117,27 +118,25 @@ namespace
         }
 
         /**
-         * @brief Invoke connection callback chain on connect.
+         * @brief Handle Particle connect event.
          */
         void onConnected()
         {
-            SFBLE& ble = SFBLE::getInstance();
-            ble.setConnectionCallback(bleConnectionThunk, &ble);
+            SFBLE &ble = SFBLE::getInstance();
             bleConnectionThunk(true, &ble);
         }
 
         /**
-         * @brief Invoke connection callback chain on disconnect.
+         * @brief Handle Particle disconnect event.
          */
         void onDisconnected()
         {
-            SFBLE& ble = SFBLE::getInstance();
-            ble.setConnectionCallback(bleConnectionThunk, &ble);
+            SFBLE &ble = SFBLE::getInstance();
             bleConnectionThunk(false, &ble);
         }
 
         /**
-         * @brief Forward control writes to registered handler.
+         * @brief Forward control writes to wrapper.
          * @param data Control payload bytes.
          * @param len Payload length.
          */
@@ -152,48 +151,37 @@ namespace
          * @param isConnected True if connected, false otherwise.
          * @param context Pointer to SFBLE instance.
          */
-        static void bleConnectionThunk(bool isConnected, void* context);
+        static void bleConnectionThunk(bool isConnected, void *context)
+        {
+            SFBLE *ble = static_cast<SFBLE *>(context);
+            if (!ble)
+            {
+                return;
+            }
+
+            ble->handleConnectionEvent(isConnected);
+        }
+
         /**
          * @brief Bridge control writes to SFBLE instance.
          * @param data Control payload.
          * @param len Payload length.
          * @param context Pointer to SFBLE instance.
          */
-        static void bleControlThunk(const uint8_t* data, size_t len, 
-                                                        void* context);
+        static void bleControlThunk(const uint8_t *data, size_t len, void *context)
+        {
+            SFBLE *ble = static_cast<SFBLE *>(context);
+            if (!ble)
+            {
+                return;
+            }
+
+            ble->handleControlEvent(data, len);
+        }
     };
+} // namespace
 
-    void ParticleBleBackend::bleConnectionThunk(bool isConnected, void* context)
-    {
-        SFBLE* ble = static_cast<SFBLE*>(context);
-        if (!ble)
-        {
-            return;
-        }
-
-        ble->connected = isConnected;
-
-        if (ble->connectionCallback)
-        {
-            ble->connectionCallback(isConnected, ble->connectionContext);
-        }
-    }
-
-    void ParticleBleBackend::bleControlThunk(const uint8_t* data, size_t len, 
-                                                                void* context)
-    {
-        SFBLE* ble = static_cast<SFBLE*>(context);
-        if (!ble)
-        {
-            return;
-        }
-
-        if (ble->controlCallback)
-        {
-            ble->controlCallback(data, len, ble->controlContext);
-        }
-    }
-}
+#endif // SF_PLATFORM == SF_PLATFORM_PARTICLE
 
 /**
  * @brief Get singleton SFBLE instance.
@@ -205,6 +193,9 @@ SFBLE& SFBLE::getInstance(void)
     return instance;
 }
 
+/**
+ * @brief Construct default wrapper state.
+ */
 SFBLE::SFBLE() :
     initialized(false),
     connected(false),
@@ -213,6 +204,33 @@ SFBLE::SFBLE() :
     connectionCallback(nullptr),
     connectionContext(nullptr)
 {
+}
+
+/**
+ * @brief Internal connection event handler.
+ * @param isConnected true if connected, false otherwise.
+ */
+void SFBLE::handleConnectionEvent(bool isConnected)
+{
+    this->connected = isConnected;
+
+    if (this->connectionCallback)
+    {
+        this->connectionCallback(isConnected, this->connectionContext);
+    }
+}
+
+/**
+ * @brief Internal control event handler.
+ * @param data Pointer to received payload.
+ * @param len Payload length.
+ */
+void SFBLE::handleControlEvent(const uint8_t *data, size_t len)
+{
+    if (this->controlCallback)
+    {
+        this->controlCallback(data, len, this->controlContext);
+    }
 }
 
 /**
@@ -234,9 +252,7 @@ bool SFBLE::init(void)
     BLE.onConnected(ParticleBleBackend::onConnectedStatic, &backend);
     BLE.onDisconnected(ParticleBleBackend::onDisconnectedStatic, &backend);
 
-    // Register characteristics by referencing them before advertising.
-    // Particle associates the characteristic with the given service UUID in the
-    // BleCharacteristic constructor.
+    // Ensure characteristic objects are instantiated before advertising.
     (void)backend.telemetryCharacteristic;
     (void)backend.controlCharacteristic;
 

--- a/src/ble/sf_ble.cpp
+++ b/src/ble/sf_ble.cpp
@@ -346,3 +346,5 @@ void SFBLE::setConnectionCallback(connection_callback_t cb, void* context)
     this->connectionCallback = cb;
     this->connectionContext = context;
 }
+
+#endif // SF_PLATFORM == SF_PLATFORM_PARTICLE

--- a/src/ble/sf_ble.cpp
+++ b/src/ble/sf_ble.cpp
@@ -1,132 +1,353 @@
 /**
- * @file sf_ble.hpp
- * @brief Platform Smartfin BLE wrapper interface.
+ * @file sf_ble.cpp
+ * @brief Particle-backed implementation of the platform-adaptable BLE wrapper.
  * @author Charlie Kushelevsky (ckushelevsky@ucsd.edu)
  * @date 3-9-2026
  */
 
-#ifndef __SF_BLE_HPP__
-#define __SF_BLE_HPP__
+#include "sf_ble.hpp"
 
-#include <stddef.h>
-#include <stdint.h>
+#include "cli/conio.hpp"
+#include "product.hpp"
+#include "sf_ble_defs.hpp"
+
+#if SF_PLATFORM == SF_PLATFORM_PARTICLE
+#include "Particle.h"
+#endif
+
+#if SF_PLATFORM == SF_PLATFORM_PARTICLE
+
+namespace
+{
+    /** @brief Particle-specific UUID objects. */
+    BleUuid g_serviceUuid(sf::bledefs::SERVICE_UUID);
+    BleUuid g_telemetryUuid(sf::bledefs::TELEMETRY_CHAR_UUID);
+    BleUuid g_controlUuid(sf::bledefs::CONTROL_CHAR_UUID);
+
+    /**
+     * @brief Particle BLE backend that wires characteristics and event hooks.
+     *
+     * This class is intentionally confined to this translation unit so the rest
+     * of the codebase does not depend on Particle BLE types.
+     */
+    class ParticleBleBackend
+    {
+    public:
+        /**
+         * @brief Construct BLE characteristics and hook control handler.
+         */
+        ParticleBleBackend()
+            : telemetryCharacteristic("tele",
+                                      BleCharacteristicProperty::NOTIFY,
+                                      g_telemetryUuid,
+                                      g_serviceUuid),
+              controlCharacteristic("ctrl",
+                                    BleCharacteristicProperty::WRITE_WO_RSP,
+                                    g_controlUuid,
+                                    g_serviceUuid,
+                                    ParticleBleBackend::onControlReceivedStatic,
+                                    this)
+        {
+        }
+
+        /** @brief Telemetry characteristic for fin -> watch data. */
+        BleCharacteristic telemetryCharacteristic;
+
+        /** @brief Control characteristic for watch -> fin commands. */
+        BleCharacteristic controlCharacteristic;
+
+        /** @brief Access singleton backend instance. */
+        static ParticleBleBackend &getInstance()
+        {
+            static ParticleBleBackend instance;
+            return instance;
+        }
+
+        /**
+         * @brief Particle connect callback shim.
+         * @param peer Connected peer (unused).
+         * @param context Pointer to backend instance.
+         */
+        static void onConnectedStatic(const BlePeerDevice &peer, void *context)
+        {
+            (void)peer;
+            ParticleBleBackend *self = static_cast<ParticleBleBackend *>(context);
+            if (self)
+            {
+                self->onConnected();
+            }
+        }
+
+        /**
+         * @brief Particle disconnect callback shim.
+         * @param peer Disconnected peer (unused).
+         * @param context Pointer to backend instance.
+         */
+        static void onDisconnectedStatic(const BlePeerDevice &peer, void *context)
+        {
+            (void)peer;
+            ParticleBleBackend *self = static_cast<ParticleBleBackend *>(context);
+            if (self)
+            {
+                self->onDisconnected();
+            }
+        }
+
+        /**
+         * @brief Particle control-write callback shim.
+         * @param data Received payload.
+         * @param len Number of bytes in payload.
+         * @param peer Peer device (unused).
+         * @param context Pointer to backend instance.
+         */
+        static void onControlReceivedStatic(const uint8_t *data,
+                                            size_t len,
+                                            const BlePeerDevice &peer,
+                                            void *context)
+        {
+            (void)peer;
+            ParticleBleBackend *self = static_cast<ParticleBleBackend *>(context);
+            if (self)
+            {
+                self->onControlReceived(data, len);
+            }
+        }
+
+        /**
+         * @brief Handle Particle connect event.
+         */
+        void onConnected()
+        {
+            SFBLE &ble = SFBLE::getInstance();
+            bleConnectionThunk(true, &ble);
+        }
+
+        /**
+         * @brief Handle Particle disconnect event.
+         */
+        void onDisconnected()
+        {
+            SFBLE &ble = SFBLE::getInstance();
+            bleConnectionThunk(false, &ble);
+        }
+
+        /**
+         * @brief Forward control writes to wrapper.
+         * @param data Control payload bytes.
+         * @param len Payload length.
+         */
+        void onControlReceived(const uint8_t *data, size_t len)
+        {
+            SFBLE &ble = SFBLE::getInstance();
+            bleControlThunk(data, len, &ble);
+        }
+
+        /**
+         * @brief Bridge connection events to SFBLE instance.
+         * @param isConnected True if connected, false otherwise.
+         * @param context Pointer to SFBLE instance.
+         */
+        static void bleConnectionThunk(bool isConnected, void *context)
+        {
+            SFBLE *ble = static_cast<SFBLE *>(context);
+            if (!ble)
+            {
+                return;
+            }
+
+            ble->handleConnectionEvent(isConnected);
+        }
+
+        /**
+         * @brief Bridge control writes to SFBLE instance.
+         * @param data Control payload.
+         * @param len Payload length.
+         * @param context Pointer to SFBLE instance.
+         */
+        static void bleControlThunk(const uint8_t *data, size_t len, void *context)
+        {
+            SFBLE *ble = static_cast<SFBLE *>(context);
+            if (!ble)
+            {
+                return;
+            }
+
+            ble->handleControlEvent(data, len);
+        }
+    };
+} // namespace
+
+#endif // SF_PLATFORM == SF_PLATFORM_PARTICLE
 
 /**
- * @brief Smartfin BLE wrapper.
- *
- * Hides Particle BLE types from the rest of the codebase so porting to a
- * different chip requires changes mostly in the implementation file.
- *
- * @note Current intent: peripheral role with one telemetry notify
- * characteristic and an optional control write characteristic
- * inside a single custom service.
+ * @brief Get singleton SFBLE instance.
+ * @return Reference to SFBLE.
  */
-class SFBLE
+SFBLE &SFBLE::getInstance(void)
 {
-public:
-    /** @brief Callback invoked on control data received. */
-    typedef void (*control_rx_callback_t)(const uint8_t *data, size_t len, void *context);
+    static SFBLE instance;
+    return instance;
+}
 
-    /** @brief Callback invoked on connect/disconnect events. */
-    typedef void (*connection_callback_t)(bool connected, void *context);
+/**
+ * @brief Construct default wrapper state.
+ */
+SFBLE::SFBLE()
+    : initialized(false), connected(false), controlCallback(nullptr), controlContext(nullptr),
+      connectionCallback(nullptr), connectionContext(nullptr)
+{
+}
 
-    /** @brief Get singleton instance. */
-    static SFBLE &getInstance(void);
+/**
+ * @brief Internal connection-event handler.
+ * @param isConnected true if connected, false otherwise.
+ */
+void SFBLE::handleConnectionEvent(bool isConnected)
+{
+    this->connected = isConnected;
 
-    /**
-     * @brief Initialize BLE stack and register service/characteristics.
-     * @return true on success, false on failure.
-     */
-    bool init(void);
+    if (this->connectionCallback)
+    {
+        this->connectionCallback(isConnected, this->connectionContext);
+    }
+}
 
-    /**
-     * @brief Start BLE advertising.
-     * @return true on success, false on failure.
-     */
-    bool startAdvertising(void);
+/**
+ * @brief Internal control-event handler.
+ * @param data Pointer to received payload.
+ * @param len Payload length.
+ */
+void SFBLE::handleControlEvent(const uint8_t *data, size_t len)
+{
+    if (this->controlCallback)
+    {
+        this->controlCallback(data, len, this->controlContext);
+    }
+}
 
-    /**
-     * @brief Stop BLE advertising.
-     * @return true on success, false on failure.
-     */
-    bool stopAdvertising(void);
+/**
+ * @brief Initialize BLE stack and register characteristics.
+ * @return true on success, false otherwise.
+ */
+bool SFBLE::init(void)
+{
+    if (this->initialized)
+    {
+        return true;
+    }
 
-    /**
-     * @brief Returns true if a central is connected.
-     * @return true when a peer is connected, otherwise false.
-     */
-    bool isConnected(void) const;
+#if SF_PLATFORM == SF_PLATFORM_PARTICLE
+    ParticleBleBackend &backend = ParticleBleBackend::getInstance();
 
-    /**
-     * @brief Send telemetry bytes to connected central using NOTIFY.
-     *
-     * @param pData Pointer to telemetry payload.
-     * @param len Number of bytes to send.
-     * @return true on success, false on failure.
-     */
-    bool notifyTelemetry(const void *pData, size_t len);
+    BLE.on();
+    BLE.setDeviceName(sf::bledefs::DEVICE_NAME);
+    BLE.onConnected(ParticleBleBackend::onConnectedStatic, &backend);
+    BLE.onDisconnected(ParticleBleBackend::onDisconnectedStatic, &backend);
 
-    /**
-     * @brief Register callback for incoming control data.
-     *
-     * @param cb Callback function invoked on received control bytes.
-     * @param context User context pointer passed to the callback.
-     */
-    void setControlCallback(control_rx_callback_t cb, void *context);
+    // Ensure characteristic objects are instantiated before advertising.
+    (void)backend.telemetryCharacteristic;
+    (void)backend.controlCharacteristic;
 
-    /**
-     * @brief Register callback for connect/disconnect events.
-     *
-     * @param cb Callback function invoked on connection state changes.
-     * @param context User context pointer passed to the callback.
-     */
-    void setConnectionCallback(connection_callback_t cb, void *context);
-    /**
-     * @brief Internal helper invoked by platform backend on connect/disconnect.
-     *
-     * Updates internal state and forwards to the user callback if registered.
-     *
-     * @param isConnected true if connected, false if disconnected
-     */
-    void handleConnectionEvent(bool isConnected);
+    this->initialized = true;
+    return true;
+#else
+    return false;
+#endif
+}
 
-    /**
-     * @brief Internal helper invoked by platform backend on control RX.
-     *
-     * Forwards received control data to the registered callback if present.
-     *
-     * @param data Pointer to received data
-     * @param len Number of bytes received
-     */
-    void handleControlEvent(const uint8_t *data, size_t len);
+/**
+ * @brief Begin advertising the Smartfin BLE service.
+ * @return true on success, false otherwise.
+ */
+bool SFBLE::startAdvertising(void)
+{
+    if (!this->initialized)
+    {
+        return false;
+    }
 
-private:
-    /** @brief Private default constructor to enforce singleton. */
-    SFBLE();
+#if SF_PLATFORM == SF_PLATFORM_PARTICLE
+    BleAdvertisingData advData;
+    advData.appendServiceUUID(BleUuid(sf::bledefs::SERVICE_UUID));
+    BLE.advertise(&advData);
+    return true;
+#else
+    return false;
+#endif
+}
 
-    /** @brief Deleted copy constructor (singleton). */
-    SFBLE(const SFBLE &);
+/**
+ * @brief Stop BLE advertising.
+ * @return true on success, false otherwise.
+ */
+bool SFBLE::stopAdvertising(void)
+{
+    if (!this->initialized)
+    {
+        return false;
+    }
 
-    /** @brief Deleted assignment operator (singleton). */
-    SFBLE &operator=(const SFBLE &);
+#if SF_PLATFORM == SF_PLATFORM_PARTICLE
+    BLE.stopAdvertising();
+    return true;
+#else
+    return false;
+#endif
+}
 
-    /** @brief True after BLE stack/characteristics are initialized. */
-    bool initialized;
+/**
+ * @brief Report connection status.
+ * @return true when a central is connected, else false.
+ */
+bool SFBLE::isConnected(void) const
+{
+    return this->connected;
+}
 
-    /** @brief True when a central is currently connected. */
-    bool connected;
+/**
+ * @brief Notify telemetry payload to connected central.
+ * @param pData Pointer to payload.
+ * @param len Payload length in bytes.
+ * @return true on success, false on failure.
+ */
+bool SFBLE::notifyTelemetry(const void *pData, size_t len)
+{
+    if (!this->initialized || !this->connected || !pData)
+    {
+        return false;
+    }
 
-    /** @brief Registered control-data callback. */
-    control_rx_callback_t controlCallback;
+    if (len == 0 || len > sf::bledefs::MAX_NOTIFY_LEN)
+    {
+        return false;
+    }
 
-    /** @brief User context for control callback. */
-    void *controlContext;
+#if SF_PLATFORM == SF_PLATFORM_PARTICLE
+    ParticleBleBackend &backend = ParticleBleBackend::getInstance();
+    return backend.telemetryCharacteristic.setValue(static_cast<const uint8_t *>(pData), len);
+#else
+    return false;
+#endif
+}
 
-    /** @brief Registered connection-state callback. */
-    connection_callback_t connectionCallback;
+/**
+ * @brief Register callback for incoming control data.
+ * @param cb Callback function pointer.
+ * @param context User context passed to callback.
+ */
+void SFBLE::setControlCallback(control_rx_callback_t cb, void *context)
+{
+    this->controlCallback = cb;
+    this->controlContext = context;
+}
 
-    /** @brief User context for connection callback. */
-    void *connectionContext;
-};
-
-#endif // __SF_BLE_HPP__
+/**
+ * @brief Register callback for connection state changes.
+ * @param cb Callback function pointer.
+ * @param context User context passed to callback.
+ */
+void SFBLE::setConnectionCallback(connection_callback_t cb, void *context)
+{
+    this->connectionCallback = cb;
+    this->connectionContext = context;
+}

--- a/src/ble/sf_ble.cpp
+++ b/src/ble/sf_ble.cpp
@@ -34,7 +34,20 @@ namespace
     {
     public:
         /**
-         * @brief Construct BLE characteristics and hook control handler.
+         * @brief Construct and register both GATT characteristics.
+         *
+         * Particle registers a @c BleCharacteristic into the GATT server at
+         * construction time, so both characteristics must be fully described
+         * here rather than in @c init().
+         *
+         * @c telemetryCharacteristic — short name @c "tele", property NOTIFY,
+         * carries fin→watch data. No write callback; the central subscribes and
+         * receives notifications pushed by @c notifyTelemetry().
+         *
+         * @c controlCharacteristic — short name @c "ctrl", property
+         * WRITE_WO_RSP, carries watch→fin commands. Registers
+         * @c onControlReceivedStatic as the write callback with @c this as
+         * context so Particle can invoke it as a plain C function pointer.
          */
         ParticleBleBackend()
             : telemetryCharacteristic("tele",
@@ -56,7 +69,18 @@ namespace
         /** @brief Control characteristic for watch -> fin commands. */
         BleCharacteristic controlCharacteristic;
 
-        /** @brief Access singleton backend instance. */
+        /**
+         * @brief Access the singleton backend instance.
+         *
+         * A single instance is required because each @c BleCharacteristic
+         * object represents one physical GATT entry. Constructing a second
+         * instance would attempt to register duplicate characteristics and
+         * corrupt the GATT table. The static-local pattern also controls
+         * construction order: the instance is created on the first call to
+         * @c getInstance(), which happens inside @c SFBLE::init() after
+         * @c BLE.on(), guaranteeing the GATT server is live before any
+         * characteristic tries to register.
+         */
         static ParticleBleBackend &getInstance()
         {
             static ParticleBleBackend instance;

--- a/src/ble/sf_ble.hpp
+++ b/src/ble/sf_ble.hpp
@@ -1,0 +1,111 @@
+/**
+ * @file sf_ble.hpp
+ * @brief Platform Smartfin BLE wrapper interface.
+ * @author Charlie Kushelevsky (ckushelevsky@ucsd.edu)
+ * @date 3-9-2026
+ */
+
+#ifndef __SF_BLE_HPP__
+#define __SF_BLE_HPP__
+
+
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @brief Smartfin BLE wrapper.
+ *
+ * Hides Particle BLE types from the rest of the codebase so porting to a
+ * different chip requires changes mostly in the implementation file.
+ * @note Current intent: peripheral role with one telemetry notify
+ * characteristic and an optional control write characteristic
+ * inside a single custom service.
+ */
+class SFBLE
+{
+public:
+    /** @brief Callback invoked on control data received. */
+    typedef void (*control_rx_callback_t)(const uint8_t* data, size_t len, void* context);
+    /** @brief Callback invoked on connect/disconnect events. */
+    typedef void (*connection_callback_t)(bool connected, void* context);
+
+    /** @brief Get singleton instance. */
+    static SFBLE& getInstance(void);
+
+    /**
+     * @brief Initialize BLE stack and register service/characteristics.
+     * @return true on success, false on failure.
+     */
+    bool init(void);
+
+    /**
+     * @brief Start BLE advertising.
+     *
+     * @return true on success, false on failure.
+     */
+    bool startAdvertising(void);
+
+    /**
+     * @brief Stop BLE advertising.
+     *
+     * @return true on success, false on failure.
+     */
+    bool stopAdvertising(void);
+
+    /**
+     * @brief Returns true if a central is connected.
+     * @return true when a peer is connected, otherwise false.
+     */
+    bool isConnected(void) const;
+
+    /**
+     * @brief Send telemetry bytes to connected central using NOTIFY.
+     *
+     * @param pData Pointer to telemetry payload.
+     * @param len Number of bytes to send (must be >0 and <= MAX_NOTIFY_LEN).
+     * @return true on success, false on failure.
+     */
+    bool notifyTelemetry(const void* pData, size_t len);
+
+    /**
+     * @brief Register callback for incoming control data.
+     *
+     * @param cb Callback function invoked on received control bytes.
+     * @param context User context pointer passed to the callback.
+     */
+    void setControlCallback(control_rx_callback_t cb, void* context);
+
+    /**
+     * @brief Register callback for connect/disconnect events.
+     *
+     * @param cb Callback function invoked on connection state changes.
+     * @param context User context pointer passed to the callback.
+     */
+    void setConnectionCallback(connection_callback_t cb, void* context);
+
+private:
+    /** @brief Private default constructor to enforce singleton. */
+    SFBLE();
+    /** @brief Deleted copy constructor (singleton). */
+    SFBLE(const SFBLE&);
+    /** @brief Deleted assignment operator (singleton). */
+    SFBLE& operator=(const SFBLE&);
+
+    /** @brief True after BLE stack/characteristics are initialized. */
+    bool initialized;
+    /** @brief True when a central is currently connected. */
+    bool connected;
+
+    /** @brief Registered control-data callback. */
+    control_rx_callback_t controlCallback;
+    /** @brief User context for control callback. */
+    void* controlContext;
+
+    /** @brief Registered connection-state callback. */
+    connection_callback_t connectionCallback;
+    /** @brief User context for connection callback. */
+    void* connectionContext;
+};
+
+#endif // __SF_BLE_HPP__

--- a/src/ble/sf_ble.hpp
+++ b/src/ble/sf_ble.hpp
@@ -13,6 +13,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/* Forward declare backend shim for friendship. */
+class ParticleBleBackend;
+
 /**
  * @brief Smartfin BLE wrapper.
  *
@@ -106,6 +109,9 @@ private:
     connection_callback_t connectionCallback;
     /** @brief User context for connection callback. */
     void* connectionContext;
+
+    /* Allow backend shim direct access to internal state. */
+    friend class ParticleBleBackend;
 };
 
 #endif // __SF_BLE_HPP__

--- a/src/ble/sf_ble.hpp
+++ b/src/ble/sf_ble.hpp
@@ -25,21 +25,23 @@ class SFBLE
 {
 public:
     /**
-     * @brief Callback invoked on control data received.
+     * @brief Callback invoked when the watch writes to the control characteristic.
      *
-     * @param data raw payload
-     * @param len raw payload
-     * @param context lets an object pass 'this' pointer
-     * so the callback can reach instance state without a global.
+     * @param data  Pointer to the raw bytes written by the peer.
+     * @param len   Number of bytes in @p data.
+     * @param context Caller-supplied pointer passed back verbatim; typically
+     *                @c this so the callback can reach instance state without
+     *                a global.
      */
     typedef void (*control_rx_callback_t)(const uint8_t *data, size_t len, void *context);
 
     /**
-     * @brief called when a central (watch) connects or disconnects
+     * @brief Callback invoked when a central connects or disconnects.
      *
-     * @param connected is true on connect
-     * @param context lets an object pass 'this' pointer
-     * so the callback can reach instance state without a global.
+     * @param connected  @c true on connect, @c false on disconnect.
+     * @param context Caller-supplied pointer passed back verbatim; typically
+     *                @c this so the callback can reach instance state without
+     *                a global.
      */
     typedef void (*connection_callback_t)(bool connected, void* context);
 

--- a/src/ble/sf_ble.hpp
+++ b/src/ble/sf_ble.hpp
@@ -24,10 +24,23 @@
 class SFBLE
 {
 public:
-    /** @brief Callback invoked on control data received. */
+    /**
+     * @brief Callback invoked on control data received.
+     *
+     * @param data raw payload
+     * @param len raw payload
+     * @param context lets an object pass 'this' pointer
+     * so the callback can reach instance state without a global.
+     */
     typedef void (*control_rx_callback_t)(const uint8_t *data, size_t len, void *context);
 
-    /** @brief Callback invoked on connect/disconnect events. */
+    /**
+     * @brief called when a central (watch) connects or disconnects
+     *
+     * @param connected is true on connect
+     * @param context lets an object pass 'this' pointer
+     * so the callback can reach instance state without a global.
+     */
     typedef void (*connection_callback_t)(bool connected, void* context);
 
     /** @brief Get singleton instance. */

--- a/src/ble/sf_ble.hpp
+++ b/src/ble/sf_ble.hpp
@@ -8,8 +8,6 @@
 #ifndef __SF_BLE_HPP__
 #define __SF_BLE_HPP__
 
-
-
 #include <stddef.h>
 #include <stdint.h>
 
@@ -18,6 +16,7 @@
  *
  * Hides Particle BLE types from the rest of the codebase so porting to a
  * different chip requires changes mostly in the implementation file.
+ *
  * @note Current intent: peripheral role with one telemetry notify
  * characteristic and an optional control write characteristic
  * inside a single custom service.
@@ -26,7 +25,8 @@ class SFBLE
 {
 public:
     /** @brief Callback invoked on control data received. */
-    typedef void (*control_rx_callback_t)(const uint8_t* data, size_t len, void* context);
+    typedef void (*control_rx_callback_t)(const uint8_t *data, size_t len, void *context);
+
     /** @brief Callback invoked on connect/disconnect events. */
     typedef void (*connection_callback_t)(bool connected, void* context);
 
@@ -41,14 +41,12 @@ public:
 
     /**
      * @brief Start BLE advertising.
-     *
      * @return true on success, false on failure.
      */
     bool startAdvertising(void);
 
     /**
      * @brief Stop BLE advertising.
-     *
      * @return true on success, false on failure.
      */
     bool stopAdvertising(void);
@@ -63,7 +61,7 @@ public:
      * @brief Send telemetry bytes to connected central using NOTIFY.
      *
      * @param pData Pointer to telemetry payload.
-     * @param len Number of bytes to send (must be >0 and <= MAX_NOTIFY_LEN).
+     * @param len Number of bytes to send.
      * @return true on success, false on failure.
      */
     bool notifyTelemetry(const void* pData, size_t len);
@@ -83,27 +81,50 @@ public:
      * @param context User context pointer passed to the callback.
      */
     void setConnectionCallback(connection_callback_t cb, void* context);
+    /**
+     * @brief Internal helper invoked by platform backend on connect/disconnect.
+     *
+     * Updates internal state and forwards to the user callback if registered.
+     *
+     * @param isConnected true if connected, false if disconnected
+     */
+    void handleConnectionEvent(bool isConnected);
+
+    /**
+     * @brief Internal helper invoked by platform backend on control RX.
+     *
+     * Forwards received control data to the registered callback if present.
+     *
+     * @param data Pointer to received data
+     * @param len Number of bytes received
+     */
+    void handleControlEvent(const uint8_t *data, size_t len);
 
 private:
     /** @brief Private default constructor to enforce singleton. */
     SFBLE();
+
     /** @brief Deleted copy constructor (singleton). */
     SFBLE(const SFBLE&);
+
     /** @brief Deleted assignment operator (singleton). */
     SFBLE& operator=(const SFBLE&);
 
     /** @brief True after BLE stack/characteristics are initialized. */
     bool initialized;
+
     /** @brief True when a central is currently connected. */
     bool connected;
 
-    /** @brief Registered control-data callback. */
+    /** @brief Registered control data callback. */
     control_rx_callback_t controlCallback;
+
     /** @brief User context for control callback. */
     void* controlContext;
 
-    /** @brief Registered connection-state callback. */
+    /** @brief Registered connection state callback. */
     connection_callback_t connectionCallback;
+
     /** @brief User context for connection callback. */
     void* connectionContext;
 };

--- a/src/ble/sf_ble_defs.hpp
+++ b/src/ble/sf_ble_defs.hpp
@@ -1,0 +1,57 @@
+/**
+ * @file sf_ble_defs.hpp
+ * @brief Smartfin BLE protocol identifiers and sizing constants.
+ * @author Charlie Kushelevsky
+ * @date 3-9-2026
+ */
+#ifndef __SF_BLEDEFS_HPP__
+#define __SF_BLEDEFS_HPP__
+
+
+#include "product.hpp"
+#include <cstddef>
+
+namespace sf
+{
+namespace bledefs
+{
+
+/**
+ * @brief Protocol/interface identifier block for Smartfin BLE.
+ *
+ * These values are compile-time constants (not NVRAM settings). Replace the
+ * example UUID strings with your own generated UUIDs when finalizing the BLE
+ * profile.
+ */
+
+/** @brief Custom Smartfin live telemetry service UUID. */
+inline constexpr const char* SERVICE_UUID =
+    "12345678-1234-1234-1234-1234567890AB";
+
+/** @brief Characteristic used for fin -> watch live telemetry. */
+inline constexpr const char* TELEMETRY_CHAR_UUID =
+    "12345678-1234-1234-1234-1234567890AC";
+
+/** @brief Optional characteristic used for watch -> fin commands/config. */
+inline constexpr const char* CONTROL_CHAR_UUID =
+    "12345678-1234-1234-1234-1234567890AD";
+
+/** @brief Short local BLE device name shown during advertising. */
+inline constexpr const char* DEVICE_NAME = "Smartfin";
+
+/**
+ * @brief Max notification payload bytes.
+ *
+ * 236 bytes is the efficient upper bound in common Particle BLE cases; above
+ * that, fragmentation can reduce throughput.
+ */
+inline constexpr std::size_t MAX_NOTIFY_LEN = 236;
+
+/** 
+ * @brief Max command/control payload bytes accepted from the peer. 
+ */
+inline constexpr std::size_t MAX_CONTROL_LEN = 64;
+
+}} // namespace sf::bledefs
+
+#endif // __SF_BLEDEFS_HPP__

--- a/src/ble/sf_ble_defs.hpp
+++ b/src/ble/sf_ble_defs.hpp
@@ -1,7 +1,7 @@
 /**
  * @file sf_ble_defs.hpp
  * @brief Smartfin BLE protocol identifiers and sizing constants.
- * @author Charlie Kushelevsky
+ * @author Charlie Kushelevsky (ckushelevsky@ucsd.edu)
  * @date 3-9-2026
  */
 #ifndef __SF_BLEDEFS_HPP__
@@ -25,16 +25,13 @@ namespace bledefs
  */
 
 /** @brief Custom Smartfin live telemetry service UUID. */
-inline constexpr const char* SERVICE_UUID =
-    "12345678-1234-1234-1234-1234567890AB";
+inline constexpr const char *SERVICE_UUID = "a86d7b16-dd6c-434b-a7ee-f0ca33ac614c";
 
 /** @brief Characteristic used for fin -> watch live telemetry. */
-inline constexpr const char* TELEMETRY_CHAR_UUID =
-    "12345678-1234-1234-1234-1234567890AC";
+inline constexpr const char *TELEMETRY_CHAR_UUID = "deeddb00-166e-407c-8158-7b9693ad2685";
 
 /** @brief Optional characteristic used for watch -> fin commands/config. */
-inline constexpr const char* CONTROL_CHAR_UUID =
-    "12345678-1234-1234-1234-1234567890AD";
+inline constexpr const char *CONTROL_CHAR_UUID = "c39513e6-631e-439a-9b3b-affa0635b3d1";
 
 /** @brief Short local BLE device name shown during advertising. */
 inline constexpr const char* DEVICE_NAME = "Smartfin";


### PR DESCRIPTION
- establishes the BLE-first direction for the firmware refactor
- introduces the top-level product/config policy needed for BLE streaming transition
- keeps the staged migration approach where recorder support can remain temporarily during transition